### PR TITLE
Return a single ipv4 ip for dualstack hosts

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -39,7 +39,7 @@ mkdir -p /usr/share/ovn
 /usr/share/ovn/scripts/ovn-ctl --no-monitor start_northd
 /usr/share/ovn/scripts/ovn-ctl --no-monitor start_controller
 
-encap_ip=$(ip addr show dev eth0 | grep inet | cut -f6 -d' ' | cut -f1 -d'/')
+encap_ip=$(ip -4 addr show dev eth0 | grep inet | cut -f6 -d' ' | cut -f1 -d'/')
 ovs-vsctl set Open_vSwitch . \
     external_ids:ovn-remote=unix:/var/run/ovn/ovnsb_db.sock \
     external_ids:ovn-encap-type=geneve \


### PR DESCRIPTION
Otherwise it fails:

```bash
# ip addr show dev eth0 | grep inet | cut -f6 -d' ' | cut -f1 -d'/'
10.88.0.13
fe80::a86a:a2ff:fe11:b27c
# cat /var/log/ovn/ovn-northd.log 
2021-03-24T09:16:51.418Z|00001|vlog|INFO|opened log file /var/log/ovn/ovn-northd.log
2021-03-24T09:16:51.419Z|00002|ovn_northd|INFO|OVN internal version is : [20.12.0-20.15.0-52.0]
2021-03-24T09:16:51.419Z|00003|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connecting...
2021-03-24T09:16:51.419Z|00004|reconnect|INFO|unix:/var/run/ovn/ovnsb_db.sock: connecting...
2021-03-24T09:16:51.419Z|00005|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connected
2021-03-24T09:16:51.419Z|00006|reconnect|INFO|unix:/var/run/ovn/ovnsb_db.sock: connected
2021-03-24T09:16:51.420Z|00007|ovn_northd|INFO|ovn-northd lock acquired. This ovn-northd instance is now active.
2021-03-24T09:16:51.841Z|00008|socket_util|ERR| : bad IP address " "
2021-03-24T09:16:51.841Z|00009|ovn_util|WARN|bad ip address or port for load balancer key  
2021-03-24T09:16:51.842Z|00010|socket_util|ERR| : bad IP address " "
```